### PR TITLE
PR: 검색 바 컴포넌트 제작

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
   "dependencies": {},
   "devDependencies": {
     "@babel/core": "7.9.0",
+    "@egjs/flicking-plugins": "^3.2.0",
     "@egjs/react-flicking": "^3.2.2",
     "@svgr/webpack": "4.3.3",
     "@testing-library/jest-dom": "^4.2.4",

--- a/frontend/src/components/home/Banner/index.tsx
+++ b/frontend/src/components/home/Banner/index.tsx
@@ -1,23 +1,16 @@
 import React from "react";
 import Flicking from "@egjs/react-flicking";
 import { FlickingEvent } from "@egjs/flicking";
+import { AutoPlay } from "@egjs/flicking-plugins";
+
 import styled from "styled-components";
 
 import Advertisement from "./Advertisement";
 import Indicator from "./Indicator";
 
-const TIMER = 3000;
-
 const Wrapper = styled.div`
   position: relative;
 `;
-
-function autoStart(flicking: Flicking, time: number): void {
-  setTimeout(() => {
-    flicking.next();
-    autoStart(flicking, time);
-  }, time);
-}
 
 type Advertise = {
   imageURL: string;
@@ -43,8 +36,8 @@ export default function Banner(props: Props): JSX.Element {
         circular={true}
         duration={500}
         autoResize={true}
-        ref={(e: Flicking): void => autoStart(e, TIMER)}
         onMoveEnd={(e: FlickingEvent): void => observable.trigger(e.index)}
+        plugins={[new AutoPlay(undefined, "NEXT")]}
       >
         {props.advertiseData.map((advertise, index) => (
           <Advertisement key={index} imageURL={advertise.imageURL} />

--- a/frontend/src/components/search/Searchbar/DeleteButton.tsx
+++ b/frontend/src/components/search/Searchbar/DeleteButton.tsx
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+export default styled.button`
+  background-color: transparent;
+  border: none;
+
+  width: 24px;
+  height: 24px;
+
+  outline: none;
+`;

--- a/frontend/src/components/search/Searchbar/FixedBox.tsx
+++ b/frontend/src/components/search/Searchbar/FixedBox.tsx
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+const WIDTH = 375;
+
+export default styled.div`
+  margin: 14px 16px 6px 16px;
+  padding: 16px 12px;
+  width: calc(${WIDTH}px - 32px - 24px);
+
+  display: flex;
+  flex-direction: row;
+  background-color: rgba(2, 23, 71, 0.05);
+  border-radius: 12px;
+`;

--- a/frontend/src/components/search/Searchbar/Input.tsx
+++ b/frontend/src/components/search/Searchbar/Input.tsx
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+
+export default styled.input`
+  width: calc(100% - 24px - 10px - 24px);
+  height: 24px;
+  margin-left: 8px;
+  margin-right: 16px;
+
+  background-color: transparent;
+  border: none;
+
+  font-weight: medium;
+  color: #8b95a1;
+  font-size: 17px;
+
+  :focus {
+    outline: none;
+  }
+`;

--- a/frontend/src/components/search/Searchbar/SeachIcon.tsx
+++ b/frontend/src/components/search/Searchbar/SeachIcon.tsx
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export default styled.div`
+  width: 24px;
+  height: 24px;
+  background-image: url("https://static.toss.im/icons/png/4x/icn-searchfield.png");
+  background-repeat: no-repeat;
+  background-size: 24px 24px;
+`;

--- a/frontend/src/components/search/Searchbar/index.tsx
+++ b/frontend/src/components/search/Searchbar/index.tsx
@@ -1,0 +1,76 @@
+import React, { Component } from "react";
+import styled from "styled-components";
+
+import FixedBox from "./FixedBox";
+import Input from "./Input";
+import SearchIcon from "./SeachIcon";
+import DeleteButton from "./DeleteButton";
+
+const Wrapper = styled.div`
+  width: 100%;
+
+  display: flex;
+  justify-content: center;
+  background-color: #fff;
+
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 1000;
+`;
+
+type Props = {};
+
+type States = {
+  showX: boolean;
+};
+
+export default class SearchBar extends Component<Props, States> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      showX: false,
+    };
+    this.updateFilter = this.updateFilter.bind(this);
+    this.deleteFilter = this.deleteFilter.bind(this);
+  }
+
+  updateFilter(event: React.KeyboardEvent<HTMLInputElement>): void {
+    const filter = (event.target as HTMLInputElement).value;
+
+    if (filter.length > 0) {
+      this.setState({
+        showX: true,
+      });
+    }
+  }
+
+  deleteFilter(event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void {
+    const input = (event.target as HTMLInputElement).parentNode?.querySelector(
+      "input"
+    );
+
+    if (input) {
+      input.value = "";
+    }
+
+    this.setState({
+      showX: false,
+    });
+  }
+
+  render(): JSX.Element {
+    return (
+      <Wrapper>
+        <FixedBox>
+          <SearchIcon />
+          <Input placeholder="상품 검색" onKeyUp={this.updateFilter}></Input>
+          {this.state.showX ? (
+            <DeleteButton onClick={this.deleteFilter}>X</DeleteButton>
+          ) : null}
+        </FixedBox>
+      </Wrapper>
+    );
+  }
+}

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -1,8 +1,15 @@
-import React from 'react';
-import { Layout } from '../components/common';
+import React from "react";
+import { Layout } from "../components/common";
+
+import SearchBar from "../components/search/Searchbar";
 
 const Search = (): JSX.Element => {
-  return <Layout>검색 페이지</Layout>;
+  return (
+    <Layout>
+      <SearchBar></SearchBar>
+      검색 페이지
+    </Layout>
+  );
 };
 
 export default Search;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1194,7 +1194,14 @@
   resolved "https://registry.yarnpkg.com/@egjs/component/-/component-2.1.2.tgz#c466a0a6fc6ba2d479814dcbe6ee4643c25a2e5b"
   integrity sha512-7tnPiqxbSZ0porzlm0+/O3qZdanMj0zOq0sb17wQXuaRG49XKKKJaO+SacGnZDqf308N5hzJ0m9fZ4+j+VBvXA==
 
-"@egjs/flicking@^3.4.7":
+"@egjs/flicking-plugins@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@egjs/flicking-plugins/-/flicking-plugins-3.2.0.tgz#1e4095acf98e52fc467907c33274930f2c4b6f3d"
+  integrity sha512-Kmjs58iBLFcr3Wef83zZdcS12eeN5vcY/Bhhbu0GjOfWcpf+8pBIb6nmA0aKOw0wzj47Jek6wVrsxSgpX13a7Q==
+  dependencies:
+    "@egjs/flicking" "^3.1.1"
+
+"@egjs/flicking@^3.1.1", "@egjs/flicking@^3.4.7":
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/@egjs/flicking/-/flicking-3.4.7.tgz#93ca7b9e5cd1832346f6b630afb72b021036f6a1"
   integrity sha512-RM9GHGcDOvyUBj3U6lJKCtUJiu/Z0rvivuZILymPqLPplBu8crbLp+sKkb5uVJavupp7Czssu8zLgZGNFlsIiQ==


### PR DESCRIPTION
> 검색 창에 사용할 검색 바 컴포넌트를 추가함

### related issue


### content

@egjs/flicking-plugins 모듈 설치해 플리킹의 슬라이딩을 설정

이는 직접 애니메이션을 setTimeout으로 설정한 경우,

페이지 이동 후에 setTimeout으로 next를 실행할 flicking 객체가 없어 오류가 발생하기 때문임

이를 제거하기 위해 이전에 설치한 plugin으로 슬라이딩 구현

검색에 사용되는 검색 바 컴포넌트를 제작함

이전에 개인적으로 작성한 프로젝트에서 가져왔으므로 hooks가 아닌 class형 컴포넌트로 구성함

이는 나중에 hooks형 컴포넌트로 변경 예정
