### PR TITLE
프론트엔드 가로 슬라이더 구현

### DIFF
--- a/frontend/src/components/common/Slider/Horizontal.tsx
+++ b/frontend/src/components/common/Slider/Horizontal.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import styled from 'styled-components';
+import {COLOR} from "../../../constants/style";
+
+type Props = {
+  title?: string;
+  isMore?: boolean;
+  onClick?: () => void;
+  children: any;
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  padding: 15px 0;
+`;
+
+const TitleWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 15px;
+`;
+
+const Title = styled.p`
+  font-size: .9rem;
+  font-weight: bold;
+`;
+
+const More = styled.p`
+  font-size: .9rem;
+  font-weight: bold;
+  color: ${COLOR.GREEN_1};
+`;
+
+const ItemWrapper = styled.div`
+  overflow-x: auto;
+  white-space:nowrap;
+  
+  > div {
+    margin: 0;
+    margin-right: 10px;
+    display: inline-table;
+
+    &:first-child{
+      margin-left : 15px;
+    }
+
+    &:last-child{
+      margin-right : 15px;
+    }
+  }
+`;
+
+const Horizontal = ({title = '이미지 슬라이더 제목', isMore = false, onClick, children}: Props) => {
+  return(
+    <Wrapper>
+      <TitleWrapper>
+        <Title>{title}</Title>
+        {isMore && <More onClick={onClick}>더보기 &gt; </More>}
+      </TitleWrapper>
+      <ItemWrapper>
+        {children}
+      </ItemWrapper>
+    </Wrapper>
+  )
+
+};
+
+export default Horizontal;

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -1,4 +1,5 @@
 import Layout from './Layout';
 import SVG from './Svg';
+import HorizontalSlider from './Slider/Horizontal';
 
-export { Layout, SVG };
+export { Layout, SVG, HorizontalSlider };

--- a/frontend/src/components/home/MainItem/ItemContent.tsx
+++ b/frontend/src/components/home/MainItem/ItemContent.tsx
@@ -9,12 +9,16 @@ const ItemContentWrapper = styled.div`
     margin-top:${MARGIN_TOP};
 `;
 
+const ItemTitle = styled.div`
+    white-space: break-spaces;
+`;
+
 export default function ItemContent(): JSX.Element {
     const { fontSize, title }: ItemContextType = useContext(ItemDispatch);
 
     return (
         <ItemContentWrapper>
-            <div style={{ fontSize }}>{title}</div>
+            <ItemTitle style={{ fontSize }}>{title}</ItemTitle>
             <ItemPrice></ItemPrice>
         </ItemContentWrapper>
     );

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
-import Layout from '../components/common/Layout';
+import { Layout, HorizontalSlider } from '../components/common';
 import Category from '../components/home/CategoryButtonArea';
 import MainItemContainer from '../components/home/MainItemContainer';
 import MainItemGallery from '../components/home/MainItemGallery';
 import Banner from '../components/home/Banner';
 import Recommend from '../components/home/Recommend';
 import itemData from '../ItemData.json';
+import MainItem from "../components/home/MainItem";
 
 const data = [
   {
@@ -62,15 +63,42 @@ const advertiseMockData = [
   },
 ];
 
+
+type Data = {
+  title: string;
+  price: string;
+  sale: string;
+  src: string;
+  width?: string;
+};
+
 export default function Home(): JSX.Element {
   return (
     <Layout>
       <Banner advertiseData={advertiseMockData}></Banner>
       <Category></Category>
-      <MainItemGallery data={data.slice(0, 4)}></MainItemGallery>
+      <HorizontalSlider title={'고객님을 위해 준비한 상품'}>
+        {
+          data.map((item: Data, idx: number) =>
+              <MainItem key={idx + ""} {...item}/>)
+        }
+      </HorizontalSlider>
+      <MainItemGallery data={data.slice(0, 4)}/>
       <MainItemContainer data={itemData.slice(0, 30)}>
         지금 뭐 먹지?
       </MainItemContainer>
+      <HorizontalSlider title={'새로 나왔어요'} isMore onClick={() => {console.log('새로 나온거 더보기...')}}>
+        {
+          data.map((item: Data, idx: number) =>
+              <MainItem key={idx + ""} {...item}/>)
+        }
+      </HorizontalSlider>
+      <HorizontalSlider title={'요즘 잘 팔려요'} isMore onClick={() => {console.log('요즘 잘 팔리는거 더보기...')}}>
+        {
+          data.map((item: Data, idx: number) =>
+              <MainItem key={idx + ""} {...item}/>)
+        }
+      </HorizontalSlider>
       <MainItemContainer data={itemData.slice(30, 60)}>
         지금 필요한 생필품!!
       </MainItemContainer>

--- a/frontend/src/stylesheets/index.css
+++ b/frontend/src/stylesheets/index.css
@@ -3,6 +3,7 @@
   margin: 0px;
   box-sizing: border-box;
 }
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -10,12 +11,6 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-* {
-  padding: 0;
-  margin: 0;
-  box-sizing: border-box;
 }
 
 img {
@@ -28,13 +23,17 @@ img {
   -webkit-user-drag: none;
 }
 
+::-webkit-scrollbar {
+  display: none;
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
 
 .App {
-  width: 100vw;
+  width: 100%;
   height: 100vh;
   margin: 0 auto;
   border: 1px solid;


### PR DESCRIPTION
> 프론트엔드 가로 슬라이더 구현

### related issue

- #53 

### content

- components/common/Slider/Horizontal.tsx 가로 슬라이더 컴포넌트 구현
=> 자식 요소만 넘기면 wrapper 안에 슬라이더로 생기도록 구현.
- components/home/MainItem 제목 줄바꿈 적용
- stylesheets/index.css 스크롤 바 안보이도록 추가
- pages/Home.tsx에 이미지 슬라이더 컴포넌트 적용(제목별로 다르게)

