### PR TITLE
PR: 레이아웃에서 inner scroll로 내용을 표시하던 부분 수정

### DIFF
--- a/frontend/src/components/common/Layout/Footer.tsx
+++ b/frontend/src/components/common/Layout/Footer.tsx
@@ -5,6 +5,8 @@ import { NavLink } from "react-router-dom";
 import Svg from "../Svg";
 
 import { COLOR, SVG } from "../../../constants/style";
+import { FOOTER } from "../../../constants/layout";
+
 import * as ROUTES from "../../../constants/routes";
 
 const Wrap = styled.div`
@@ -13,7 +15,7 @@ const Wrap = styled.div`
   z-index: 2000;
 
   width: 100%;
-  height: 80px;
+  height: ${FOOTER.SIZE}px;
   background-color: ${COLOR.WHITE};
   display: flex;
   justify-content: space-between;

--- a/frontend/src/components/common/Layout/Footer.tsx
+++ b/frontend/src/components/common/Layout/Footer.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
-import styled from 'styled-components';
-import { NavLink } from 'react-router-dom';
+import React from "react";
+import styled from "styled-components";
+import { NavLink } from "react-router-dom";
 
-import Svg from '../Svg';
+import Svg from "../Svg";
 
-import { COLOR, SVG } from '../../../constants/style';
-import * as ROUTES from '../../../constants/routes';
+import { COLOR, SVG } from "../../../constants/style";
+import * as ROUTES from "../../../constants/routes";
 
 const Wrap = styled.div`
+  position: fixed;
+  bottom: 0;
+  z-index: 2000;
+
   width: 100%;
   height: 80px;
   background-color: ${COLOR.WHITE};

--- a/frontend/src/components/common/Layout/Header.tsx
+++ b/frontend/src/components/common/Layout/Header.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "styled-components";
 
 import { COLOR, SVG } from "../../../constants/style";
+import { HEADER } from "../../../constants/layout";
 // import Logo from '/asset/';
 
 const Layer = styled.div`
@@ -10,7 +11,7 @@ const Layer = styled.div`
   top: 0;
 
   width: 100%;
-  height: 80px;
+  height: ${HEADER.SIZE}px;
   background-color: ${COLOR.GREEN_1};
   display: flex;
   justify-content: space-between;

--- a/frontend/src/components/common/Layout/Header.tsx
+++ b/frontend/src/components/common/Layout/Header.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
-import styled from 'styled-components';
+import React from "react";
+import styled from "styled-components";
 
-import { COLOR, SVG } from '../../../constants/style';
+import { COLOR, SVG } from "../../../constants/style";
 // import Logo from '/asset/';
 
 const Layer = styled.div`
+  z-index: 3000;
+  position: fixed;
+  top: 0;
+
   width: 100%;
   height: 80px;
   background-color: ${COLOR.GREEN_1};
@@ -27,7 +31,7 @@ const Header = (): JSX.Element => {
         </svg>
       </Item>
       <div>
-        <img src="/asset/images/logo.png" width={'60px'} />
+        <img src="/asset/images/logo.png" width={"60px"} />
       </div>
       <Item></Item>
     </Layer>

--- a/frontend/src/components/common/Layout/index.tsx
+++ b/frontend/src/components/common/Layout/index.tsx
@@ -6,7 +6,6 @@ import Footer from "./Footer";
 
 const Wrapper = styled.div`
   width: 100%;
-  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -16,8 +15,7 @@ const Wrapper = styled.div`
 
 const Section = styled.div`
   width: 100%;
-  height: 100%;
-  overflow-y: auto;
+  margin: 80px 0;
 `;
 
 type Props = {

--- a/frontend/src/components/common/Layout/index.tsx
+++ b/frontend/src/components/common/Layout/index.tsx
@@ -4,6 +4,8 @@ import styled from "styled-components";
 import Header from "./Header";
 import Footer from "./Footer";
 
+import { HEADER, FOOTER } from "../../../constants/layout";
+
 const Wrapper = styled.div`
   width: 100%;
   display: flex;
@@ -15,7 +17,7 @@ const Wrapper = styled.div`
 
 const Section = styled.div`
   width: 100%;
-  margin: 80px 0;
+  margin: ${HEADER.SIZE}px 0 ${FOOTER.SIZE}px 0;
 `;
 
 type Props = {

--- a/frontend/src/constants/layout.ts
+++ b/frontend/src/constants/layout.ts
@@ -1,0 +1,7 @@
+export const HEADER = {
+  SIZE: 80,
+};
+
+export const FOOTER = {
+  SIZE: 80,
+};


### PR DESCRIPTION
> inner scroll로 구현한 프로젝트 기본 레이아웃 변경

### related issue

- #67 

### content

![레이아웃](https://user-images.githubusercontent.com/38618187/90608043-03a13380-e23d-11ea-9478-12fa471eb149.png)

기본 레이아웃에서 header, section, footer 방식으로 되어있고 section에 overflow-y 옵션이 설정되어있음

기존 구조와 동일하게 동작함을 확인

레이아웃 헤더와 푸터의 크기를 상수로 관리