### PR TITLE
프론트엔드 가로 슬라이더 컴포넌트 수정

### DIFF
--- a/frontend/src/components/common/Slider/Horizontal.test.tsx
+++ b/frontend/src/components/common/Slider/Horizontal.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import fireEvent from "@testing-library/user-event";
+import Horizontal from "./Horizontal";
+
+describe("<Horizontal />", () => {
+  // 테스트용 컴포넌트 생성
+  const setup = (props = {}) => {
+    const utils = render(
+      <Horizontal
+        title={"가로 슬라이더 테스트 코드"}
+        isMore
+        onClick={() => console.log("더보기 클릭")}
+      >
+        <div>Box 1</div>
+        <div>Box 2</div>
+      </Horizontal>
+    );
+    const { getByText } = utils;
+    const title = getByText("가로 슬라이더 테스트 코드"); // title이 있는지 확인
+    const button = getByText("더보기 >"); // button이 있는지 확인
+    return {
+      ...utils,
+      title,
+      button,
+    };
+  };
+
+  it("has title and more button ", () => {
+    const { title, button } = setup();
+    expect(title).toBeTruthy(); // 해당 값이 truthy 한 값인지 확인
+    expect(button).toBeTruthy();
+    // 리액트 render 테스트 추가?!
+  });
+  
+
+  it("calls more action", () => {
+    const onInsert = jest.fn();
+    const { button } = setup({ onInsert });
+
+    fireEvent.click(button);
+    // 버튼 클릭 후 나타날 액션에 대해 추가로 테스트
+  });
+});

--- a/frontend/src/components/common/Slider/Horizontal.tsx
+++ b/frontend/src/components/common/Slider/Horizontal.tsx
@@ -35,21 +35,28 @@ const More = styled.p`
 
 const ItemWrapper = styled.div`
   overflow-x: auto;
-  white-space: nowrap;
+  display: flex;
+  flex-wrap: nowrap;
+  -webkit-overflow-scrolling: touch; /* 끝에서 바운스 되도록*/
+  scroll-snap-type: x mandatory;
 
   > div {
     margin: 0;
-    margin-right: 10px;
-    display: inline-table;
+    margin-left: 10px;
+    flex: 0 0 auto;
 
     &:first-child {
       margin-left: 15px;
     }
 
     &:last-child {
-      margin-right: 15px;
+      margin-left: 0;
     }
   }
+`;
+
+const LastItem = styled.div`
+  width: 15px;
 `;
 
 const Horizontal = ({
@@ -62,9 +69,12 @@ const Horizontal = ({
     <Wrapper>
       <TitleWrapper>
         <Title>{title}</Title>
-        {isMore && <More onClick={onClick}>더보기 &gt; </More>}
+        {isMore && <More onClick={onClick}>더보기 &gt;</More>}
       </TitleWrapper>
-      <ItemWrapper>{children}</ItemWrapper>
+      <ItemWrapper>
+        {children}
+        <LastItem />
+      </ItemWrapper>
     </Wrapper>
   );
 };

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -79,24 +79,12 @@ export default function Home(): JSX.Element {
         <MainItemContainer data={itemData.slice(0, 30)}>
           지금 뭐 먹지?
         </MainItemContainer>
-        <HorizontalSlider
-          title={"새로 나왔어요"}
-          isMore
-          onClick={(): void => {
-            console.log("새로 나온거 더보기...");
-          }}
-        >
+        <HorizontalSlider title={"새로 나왔어요"} isMore>
           {data.map((item: Data, idx: number) => (
             <MainItem key={idx + ""} {...item} />
           ))}
         </HorizontalSlider>
-        <HorizontalSlider
-          title={"요즘 잘 팔려요"}
-          isMore
-          onClick={(): void => {
-            console.log("요즘 잘 팔리는거 더보기...");
-          }}
-        >
+        <HorizontalSlider title={"요즘 잘 팔려요"} isMore>
           {data.map((item: Data, idx: number) => (
             <MainItem key={idx + ""} {...item} />
           ))}


### PR DESCRIPTION
> frontend/components/common/Slider/Horizontal 컴포넌트 수정

### related issue

- #86 

### content

- 모바일 기기에서 위아래로 움직이는 부분 개선
- 아이템 렌더링 부분을 flex 속성으로 변경
- 마지막 요소에 빈 div 태그 추가
=> 마지막 요소에 margin 속성이 보이지 않았었다.
- pages/Home.tsx에 Horizontal 컴포넌트 사용하지 않는 속성 삭제
- Horizontal 컴포넌트에 title, 더보기 버튼이 있는지 확인
- 더보기 버튼 클릭 액션이 잘 동작하는지 확인
- 추가로 필요한 테스트 코드를 작성할 에정
