### PR TITLE
PR: 대표상품 컴포넌트 최적화

### DIFF
--- a/frontend/src/components/home/Recommend/Content.tsx
+++ b/frontend/src/components/home/Recommend/Content.tsx
@@ -3,8 +3,10 @@ import styled from "styled-components";
 
 import MainItem from "../MainItem";
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ innerHeight: number | undefined }>`
   width: 100%;
+  ${(props): string | null =>
+    props.innerHeight ? `height: ${props.innerHeight}px;` : null}
   border: 1px solid #000;
 
   display: flex;
@@ -19,9 +21,13 @@ const Row = styled.div`
   justify-content: space-between;
 `;
 
-export default function Menus(): JSX.Element {
+type Props = {
+  height?: number;
+};
+
+export default function Content(props: Props): JSX.Element {
   return (
-    <Wrapper>
+    <Wrapper innerHeight={props.height}>
       <Row>
         <MainItem></MainItem>
         <MainItem></MainItem>

--- a/frontend/src/components/home/Recommend/Menus.tsx
+++ b/frontend/src/components/home/Recommend/Menus.tsx
@@ -3,13 +3,15 @@ import Flicking from "@egjs/react-flicking";
 import { FlickingEvent } from "@egjs/flicking";
 import styled from "styled-components";
 
-import Section from "./Menu";
+import Menu from "./Menu";
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ innerHeight: number }>`
   width: 100%;
+  height: ${(props): number => props.innerHeight}px;
 `;
 
 type Props = {
+  innerHeight?: number;
   menus: Array<string>;
   store: {
     flicking: Flicking | undefined;
@@ -36,7 +38,7 @@ export default function Menus(props: Props): JSX.Element {
   };
 
   return (
-    <Wrapper>
+    <Wrapper innerHeight={props.innerHeight || 50}>
       <Flicking
         duration={500}
         gap={10}
@@ -54,7 +56,7 @@ export default function Menus(props: Props): JSX.Element {
         autoResize={true}
       >
         {props.menus.reverse().map((menu, index) => (
-          <Section key={`menu.${index}`} menu={menu} observable={observable} />
+          <Menu key={`menu.${index}`} menu={menu} observable={observable} />
         ))}
       </Flicking>
     </Wrapper>

--- a/frontend/src/components/home/Recommend/index.tsx
+++ b/frontend/src/components/home/Recommend/index.tsx
@@ -5,6 +5,8 @@ import Header from "./Header";
 import Menus from "./Menus";
 import List from "./List";
 
+import { HEADER, FOOTER } from "../../../constants/layout";
+
 const Wrapper = styled.div`
   position: relative;
   width: 100%;
@@ -33,12 +35,18 @@ export default function Recommend(): JSX.Element {
   const store = {
     flicking: undefined,
   };
+  const screeHeight = screen.height;
+  const MenusHeight = 30;
 
   return (
     <Wrapper>
       <Header />
-      <Menus menus={dummyMenuData} store={store} />
-      <List store={store} menus={dummyMenuData} />
+      <Menus innerHeight={MenusHeight} menus={dummyMenuData} store={store} />
+      <List
+        innerHeight={screeHeight - (HEADER.SIZE + FOOTER.SIZE + MenusHeight)}
+        store={store}
+        menus={dummyMenuData}
+      />
     </Wrapper>
   );
 }


### PR DESCRIPTION
> 대표 상품 컴포넌트의 UX를 최적화 하기 위한 작업

### related issue

- #80 

### content

스크롤 이벤트에 디바운싱을 추가해 불필요한 이벤트의 발생을 막음

크기를 옵션으로 prop으로 받도록 설정

하단 대표상품을 터치했을 때, 그 대표상품으로 이동하도록 구성함

대표상품으로 이동된 상태에서만 대표상품 내부 스크롤이 가능하도록 설정