### PR TITLE
PR: 검색바 hooks 컴포넌트로 변경

### DIFF
--- a/frontend/src/components/search/History/HistoryText.tsx
+++ b/frontend/src/components/search/History/HistoryText.tsx
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+
+export default styled.div`
+  font-size: 16px;
+  margin: 10px;
+`;

--- a/frontend/src/components/search/History/index.tsx
+++ b/frontend/src/components/search/History/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import styled from "styled-components";
+
+import HistoryText from "./HistoryText";
+
+const Wrapper = styled.div`
+  margin-top: 80px;
+`;
+
+export default function SearchBar(): JSX.Element {
+  return (
+    <Wrapper>
+      <HistoryText>더미 검색 1</HistoryText>
+      <HistoryText>더미 검색 2</HistoryText>
+    </Wrapper>
+  );
+}

--- a/frontend/src/components/search/Searchbar/DeleteButton.tsx
+++ b/frontend/src/components/search/Searchbar/DeleteButton.tsx
@@ -1,11 +1,33 @@
+import React from "react";
+
 import styled from "styled-components";
 
-export default styled.button`
+type Props = {
+  show: boolean;
+  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+};
+
+const Wrapper = styled.button<{ show: boolean }>`
+  display: ${(props): string => (props.show ? "block" : "none")};
   background-color: transparent;
   border: none;
 
-  width: 24px;
-  height: 24px;
+  width: 30px;
+  height: 30px;
+
+  position: absolute;
+  right: 20px;
+
+  font-size: 16px;
+  color: #8b95a1;
 
   outline: none;
 `;
+
+export default function DeleteButton(props: Props): JSX.Element {
+  return (
+    <Wrapper onClick={props.onClick} show={props.show}>
+      ╳
+    </Wrapper>
+  );
+}

--- a/frontend/src/components/search/Searchbar/FixedBox.tsx
+++ b/frontend/src/components/search/Searchbar/FixedBox.tsx
@@ -1,11 +1,8 @@
 import styled from "styled-components";
 
-const WIDTH = 375;
-
 export default styled.div`
-  margin: 14px 16px 6px 16px;
-  padding: 16px 12px;
-  width: calc(${WIDTH}px - 32px - 24px);
+  padding: 10px;
+  width: 100%;
 
   display: flex;
   flex-direction: row;

--- a/frontend/src/components/search/Searchbar/Input.tsx
+++ b/frontend/src/components/search/Searchbar/Input.tsx
@@ -1,17 +1,16 @@
 import styled from "styled-components";
 
 export default styled.input`
-  width: calc(100% - 24px - 10px - 24px);
-  height: 24px;
-  margin-left: 8px;
-  margin-right: 16px;
+  width: calc(100% - 30px - 10px);
+  height: 30px;
+  margin: 0 10px 0 10px;
 
   background-color: transparent;
   border: none;
 
   font-weight: medium;
   color: #8b95a1;
-  font-size: 17px;
+  font-size: 20px;
 
   :focus {
     outline: none;

--- a/frontend/src/components/search/Searchbar/SeachIcon.tsx
+++ b/frontend/src/components/search/Searchbar/SeachIcon.tsx
@@ -1,9 +1,13 @@
 import styled from "styled-components";
 
-export default styled.div`
-  width: 24px;
-  height: 24px;
+type Props = {
+  size?: number;
+};
+
+export default styled.div<Props>`
+  width: ${(props): number => props.size || 30}px;
+  height: ${(props): number => props.size || 30}px;
   background-image: url("https://static.toss.im/icons/png/4x/icn-searchfield.png");
   background-repeat: no-repeat;
-  background-size: 24px 24px;
+  background-size: ${(props): number => props.size || 30}px;
 `;

--- a/frontend/src/components/search/Searchbar/index.tsx
+++ b/frontend/src/components/search/Searchbar/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 
 import FixedBox from "./FixedBox";
@@ -7,46 +7,31 @@ import SearchIcon from "./SeachIcon";
 import DeleteButton from "./DeleteButton";
 
 const Wrapper = styled.div`
+  z-index: 1000;
+  position: fixed;
+  padding: 10px;
+
   width: 100%;
 
-  display: flex;
-  justify-content: center;
   background-color: #fff;
-
-  position: fixed;
-  left: 0;
-  top: 0;
-  z-index: 1000;
 `;
 
-type Props = {};
+export default function SearchBar(): JSX.Element {
+  const [showDelete, setShowDelete] = useState(false);
 
-type States = {
-  showX: boolean;
-};
-
-export default class SearchBar extends Component<Props, States> {
-  constructor(props: Props) {
-    super(props);
-
-    this.state = {
-      showX: false,
-    };
-    this.updateFilter = this.updateFilter.bind(this);
-    this.deleteFilter = this.deleteFilter.bind(this);
-  }
-
-  updateFilter(event: React.KeyboardEvent<HTMLInputElement>): void {
+  function updateFilter(event: React.KeyboardEvent<HTMLInputElement>): void {
     const filter = (event.target as HTMLInputElement).value;
 
     if (filter.length > 0) {
-      this.setState({
-        showX: true,
-      });
+      setShowDelete(true);
+    } else {
+      setShowDelete(false);
     }
   }
 
-  deleteFilter(event: React.MouseEvent<HTMLButtonElement, MouseEvent>): void {
+  function deleteFilter(
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ): void {
     const input = (event.target as HTMLInputElement).parentNode?.querySelector(
       "input"
     );
@@ -55,22 +40,16 @@ export default class SearchBar extends Component<Props, States> {
       input.value = "";
     }
 
-    this.setState({
-      showX: false,
-    });
+    setShowDelete(false);
   }
 
-  render(): JSX.Element {
-    return (
-      <Wrapper>
-        <FixedBox>
-          <SearchIcon />
-          <Input placeholder="상품 검색" onKeyUp={this.updateFilter}></Input>
-          {this.state.showX ? (
-            <DeleteButton onClick={this.deleteFilter}>X</DeleteButton>
-          ) : null}
-        </FixedBox>
-      </Wrapper>
-    );
-  }
+  return (
+    <Wrapper>
+      <FixedBox>
+        <SearchIcon />
+        <Input placeholder="상품 검색" onKeyUp={updateFilter} />
+        <DeleteButton onClick={deleteFilter} show={showDelete} />
+      </FixedBox>
+    </Wrapper>
+  );
 }

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -2,12 +2,13 @@ import React from "react";
 import { Layout } from "../components/common";
 
 import SearchBar from "../components/search/Searchbar";
+import History from "../components/search/History";
 
 const Search = (): JSX.Element => {
   return (
     <Layout>
-      <SearchBar></SearchBar>
-      검색 페이지
+      <SearchBar />
+      <History />
     </Layout>
   );
 };


### PR DESCRIPTION
> Class형 컴포넌트로 만든 검색 바를 hooks로 변경함

### related issue

- #82
- #2

### content

class형 컴포넌트로 구성되어있던 검색 바를 hooks 형 컴포넌트로 변경함

내부 styled component 들로 구성된 인자에 prop으로 속성을 받아 사용하도록 구성

추후에 사용할 검색 기록 컴포넌트의 skeleton을 추가함