### PR TITLE
프론트엔드 장바구니 페이지 상품 선택 및 수량 변경 기능 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 import Router from "./router";
 import { PopUp } from "./components/common";
-import { PopUpContext } from "./context";
+import { PopUpContext, CartContext } from "./context";
 
 function App(): JSX.Element {
   return (
     <div className="App">
       <PopUpContext.PopUpProvider>
-        <Router />
+        <CartContext.CartProvider>
+          <Router />
+        </CartContext.CartProvider>
         <PopUp />
       </PopUpContext.PopUpProvider>
     </div>

--- a/frontend/src/components/cart/CartHeader.tsx
+++ b/frontend/src/components/cart/CartHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import style from "styled-components";
 
 import { CheckBox } from "../common";
@@ -20,25 +20,28 @@ const ToggleTitle = style.p`
   margin-left: 5px;
 `;
 
-const CartHeader = (): JSX.Element => {
-  const [check, setCheck] = useState(false);
-  const [toggleTitle, setToggleTitle] = useState("모두 선택");
+type Props = {
+  isAllChecked: boolean;
+  onCheck: () => void;
+};
 
-  const onCheck = (): void => {
-    setToggleTitle("선택 해제");
-    if (check) setToggleTitle("모두 선택");
-    setCheck((state) => !state);
-  };
+const CartHeader = (props: Props): JSX.Element => {
+  const { isAllChecked, onCheck } = props;
 
   return (
     <HeaderWrapper>
       <ToggleCheck onClick={onCheck}>
-        <CheckBox isChecked={check} />
-        <ToggleTitle>{toggleTitle}</ToggleTitle>
+        <CheckBox isChecked={isAllChecked} />
+        <ToggleTitle>{isAllChecked ? "선택 해제" : "모두 선택"}</ToggleTitle>
       </ToggleCheck>
       <p>선택 비우기</p>
     </HeaderWrapper>
   );
+};
+
+CartHeader.defaultProps = {
+  isAllChecked: false,
+  onCheck: null,
 };
 
 export default CartHeader;

--- a/frontend/src/components/cart/CartList/CartItem.tsx
+++ b/frontend/src/components/cart/CartList/CartItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import style from "styled-components";
 
 import { COLOR } from "../../../constants/style";
@@ -85,30 +85,35 @@ const CounterItem = style.div`
   align-items: center;
 `;
 
-const CartItem = (props: CartItemType): JSX.Element => {
-  const { name, cost, discount, cnt, imageUrl, isChecked } = props;
-  // const [isChecked, setIsChecked] = useState(isChecked);
-  // const [count, setCount] = useState(0);
+const CounterButton = style.button`
+  border: 0;
+  background: transparent;
+  outline: none;
+  font-size: 1rem;
+`;
 
-  const onChecked = (): void => {
-    // setIsChecked((state) => !state);
-  };
+type Props = {
+  data: CartItemType;
+  onCheck: (id: number) => void;
+  onIncrease: (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    id: number
+  ) => void;
+  onDecrease: (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    id: number
+  ) => void;
+};
 
-  const minusAction = (): void => {
-    // if (cnt < 1) return;
-    // setCount((state) => state - 1);
-  };
-
-  const plusAction = (): void => {
-    // setCount((state) => state + 1);
-  };
-
+const CartItem = (props: Props): JSX.Element => {
+  const { data, onCheck, onIncrease, onDecrease } = props;
+  const { id, name, cost, discount, cnt, imageUrl, isChecked } = data;
   const salePrice = cost - Math.round(cost * (discount * 0.01));
 
   return (
     <ItemWrapper>
       <TitleWrapper>
-        <CheckBoxWrapper onClick={onChecked}>
+        <CheckBoxWrapper onClick={(): void => onCheck(id)}>
           <CheckBox isChecked={isChecked} />
           <p>{name}</p>
         </CheckBoxWrapper>
@@ -131,9 +136,24 @@ const CartItem = (props: CartItemType): JSX.Element => {
             </SaleWrapper>
           </div>
           <ChangeCounter>
-            <CounterItem onClick={minusAction}>ㅡ</CounterItem>
+            <CounterButton
+              name="minus"
+              style={{ color: cnt === 1 ? COLOR.GREY_3 : COLOR.BLACK }}
+              onClick={(
+                e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+              ): void => onDecrease(e, id)}
+            >
+              ㅡ
+            </CounterButton>
             <CounterItem>{cnt}</CounterItem>
-            <CounterItem onClick={plusAction}>+</CounterItem>
+            <CounterButton
+              name="plus"
+              onClick={(
+                e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+              ): void => onIncrease(e, id)}
+            >
+              +
+            </CounterButton>
           </ChangeCounter>
         </PriceWrapper>
       </ContentWrapper>

--- a/frontend/src/components/cart/CartList/index.tsx
+++ b/frontend/src/components/cart/CartList/index.tsx
@@ -3,6 +3,7 @@ import style from "styled-components";
 
 import CartItem from "./CartItem";
 import { CartItemType } from "../../../types/Cart";
+import { CartContext } from "../../../context";
 
 const ListWrapper = style.div`
   width: 100%;
@@ -16,10 +17,55 @@ type Props = {
 const CartList = (props: Props): JSX.Element => {
   const { data } = props;
 
+  const cartDispatch = CartContext.useCartDispatch();
+
+  const onCheckItem = (id: number): void => {
+    cartDispatch({
+      type: "CHECK_CART_ITEM",
+      payload: {
+        id,
+      },
+    });
+  };
+
+  const onDecrease = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    id: number
+  ): void => {
+    e.preventDefault();
+    cartDispatch({
+      type: "UPDATE_CART",
+      payload: {
+        id,
+        type: "minus",
+      },
+    });
+  };
+
+  const onIncrease = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    id: number
+  ): void => {
+    e.preventDefault();
+    cartDispatch({
+      type: "UPDATE_CART",
+      payload: {
+        id,
+        type: "plus",
+      },
+    });
+  };
+
   return (
     <ListWrapper>
       {data.map((item, index) => (
-        <CartItem key={index + item.name} {...item} />
+        <CartItem
+          key={index + item.name}
+          data={item}
+          onCheck={onCheckItem}
+          onIncrease={onIncrease}
+          onDecrease={onDecrease}
+        />
       ))}
     </ListWrapper>
   );

--- a/frontend/src/components/cart/CartTotal.tsx
+++ b/frontend/src/components/cart/CartTotal.tsx
@@ -7,11 +7,6 @@ type RowType = {
   justifyAttr?: string;
 };
 
-type Props = {
-  totalPrice: number;
-  deliveryTips: number;
-};
-
 const TotalWrapper = style.div`
   width: 100%;
   padding: 15px;
@@ -32,6 +27,11 @@ const Price = style.div`
 const Limit = style.div`
   color: ${COLOR.RED};
 `;
+
+type Props = {
+  totalPrice: number;
+  deliveryTips: number;
+};
 
 const CartTotal = (props: Props): JSX.Element => {
   const { totalPrice, deliveryTips } = props;

--- a/frontend/src/components/cart/OrderBtn.tsx
+++ b/frontend/src/components/cart/OrderBtn.tsx
@@ -2,10 +2,6 @@ import React from "react";
 import style from "styled-components";
 import { COLOR } from "../../constants/style";
 
-type Props = {
-  orderAction: () => void;
-};
-
 const BtnWrapper = style.div`
   width: 100%;
   padding: 15px;
@@ -44,10 +40,14 @@ const Price = style.div`
   color: ${COLOR.WHITE};
 `;
 
+type Props = {
+  orderAction: () => void;
+  totalPrice: number;
+  count: number;
+};
+
 const OrderBtn = (props: Props): JSX.Element => {
-  const { orderAction } = props;
-  const count = 0;
-  const totalPrice = 0;
+  const { orderAction, totalPrice, count } = props;
 
   return (
     <BtnWrapper>
@@ -57,6 +57,11 @@ const OrderBtn = (props: Props): JSX.Element => {
       </Btn>
     </BtnWrapper>
   );
+};
+
+OrderBtn.defaultProps = {
+  totalPrice: 0,
+  count: 0,
 };
 
 export default OrderBtn;

--- a/frontend/src/constants/style.ts
+++ b/frontend/src/constants/style.ts
@@ -6,6 +6,7 @@ const COLOR = {
   GREEN_3: "#18B0BE",
   GREY_1: "#dddddd",
   GREY_2: "#7b7a7a",
+  GREY_3: "#bbbbbb",
   WHITE: "#ffffff",
   BLACK: "#000000",
   RED: "#ff0000",

--- a/frontend/src/context/CartContext.tsx
+++ b/frontend/src/context/CartContext.tsx
@@ -1,0 +1,274 @@
+import React, { createContext, useReducer, Dispatch, useContext } from "react";
+import { CartItemType } from "../types/Cart";
+
+type Cart = {
+  cartList: Array<CartItemType>;
+  totalPrice?: number | undefined;
+  deliveryTips?: number | undefined;
+  checkItemAmount?: number | undefined;
+  isAllChecked?: boolean | undefined;
+};
+
+type CartState = {
+  totalPrice: number;
+  deliveryTips: number;
+  checkItemAmount: number;
+  isAllChecked: boolean;
+};
+
+type Action =
+  | {
+      type: "GET_CART";
+    }
+  | {
+      type: "ADD_CART";
+      payload: {
+        data: CartItemType;
+      };
+    }
+  | {
+      type: "UPDATE_CART";
+      payload: {
+        id: number;
+        type: string;
+      };
+    }
+  | {
+      type: "REMOVE_CART";
+      payload: {
+        id: number;
+      };
+    }
+  | {
+      type: "REMOVE_CHECKED_CART";
+    }
+  | {
+      type: "CHECK_CART_ITEM";
+      payload: {
+        id: number;
+      };
+    }
+  | {
+      type: "ALL_CHECK_CART_ITEM";
+    };
+
+const storage: string | null = localStorage.getItem("cart_list");
+
+const initialState: Cart = {
+  cartList: JSON.parse(storage || "[]"),
+  totalPrice: 0,
+  deliveryTips: 0,
+  checkItemAmount: 0,
+  isAllChecked: false,
+};
+
+const saveCartList = (cartList: Array<CartItemType>): void => {
+  localStorage.setItem("cart_list", JSON.stringify(cartList));
+};
+
+const allCartCheckItem = (cartList: Array<CartItemType>): boolean => {
+  let isAllChecked = true;
+  cartList.forEach((item) => {
+    if (!item.isChecked) isAllChecked = false;
+  });
+
+  return isAllChecked;
+};
+
+const getCartCheckItem = (cartList: Array<CartItemType>): number => {
+  const checkedCartItem = cartList.filter((item) => item.isChecked);
+  let totalCount = 0;
+  checkedCartItem.forEach((item) => {
+    totalCount += item.cnt;
+  });
+
+  return totalCount;
+};
+
+const getTotalPrice = (cartList: Array<CartItemType>): number => {
+  const checkedCartItem = cartList.filter((item) => item.isChecked);
+  let totalPrice = 0;
+  checkedCartItem.forEach((item) => {
+    const salePrice =
+      item.cost - Math.round(item.cost * (item.discount * 0.01));
+    totalPrice += salePrice * item.cnt;
+  });
+  return totalPrice;
+};
+
+const getDeliveryTips = (totalPrice: number): number => {
+  let deliveryTips = 0;
+
+  if (totalPrice < 10000 && totalPrice >= 5000) {
+    deliveryTips = 2500;
+  } else if (totalPrice < 20000 && totalPrice >= 10000) {
+    deliveryTips = 1500;
+  }
+
+  return deliveryTips;
+};
+
+const getUpdateState = (cartList: Array<CartItemType>): CartState => {
+  const totalPrice = getTotalPrice(cartList);
+  const checkItemAmount = getCartCheckItem(cartList);
+  const deliveryTips = getDeliveryTips(totalPrice);
+  const isAllChecked = allCartCheckItem(cartList);
+  saveCartList(cartList);
+
+  return {
+    totalPrice,
+    deliveryTips,
+    checkItemAmount,
+    isAllChecked,
+  };
+};
+
+const reducer = (state: Cart, action: Action): Cart => {
+  switch (action.type) {
+    case "GET_CART": {
+      const {
+        totalPrice,
+        checkItemAmount,
+        deliveryTips,
+        isAllChecked,
+      } = getUpdateState(state.cartList);
+      return {
+        cartList: state.cartList,
+        totalPrice,
+        deliveryTips,
+        checkItemAmount,
+        isAllChecked,
+      };
+    }
+    case "ADD_CART":
+      return state;
+    case "UPDATE_CART": {
+      const updateCartItem = state.cartList.filter(
+        (item) => item.id === action.payload.id
+      );
+      const removeCheckCartItem = state.cartList.filter(
+        (item) => item.id !== action.payload.id
+      );
+      let cnt = 0;
+      if (action.payload.type === "plus") {
+        cnt = updateCartItem[0].cnt + 1;
+      } else {
+        cnt = updateCartItem[0].cnt < 2 ? 1 : updateCartItem[0].cnt - 1;
+      }
+      const updateCartList = [
+        ...removeCheckCartItem,
+        { ...updateCartItem[0], cnt },
+      ];
+
+      const {
+        totalPrice,
+        checkItemAmount,
+        deliveryTips,
+        isAllChecked,
+      } = getUpdateState(updateCartList);
+      return {
+        cartList: updateCartList,
+        totalPrice,
+        deliveryTips,
+        checkItemAmount,
+        isAllChecked,
+      };
+    }
+    case "REMOVE_CART": {
+      const removeCheckCartItem = state.cartList.filter(
+        (item) => item.id !== action.payload.id
+      );
+      const { totalPrice, checkItemAmount, deliveryTips } = getUpdateState(
+        removeCheckCartItem
+      );
+      return {
+        cartList: removeCheckCartItem,
+        totalPrice,
+        deliveryTips,
+        checkItemAmount,
+      };
+    }
+    case "CHECK_CART_ITEM": {
+      const checkCartItem = state.cartList.filter(
+        (item) => item.id === action.payload.id
+      );
+      const removeCheckCartItem = state.cartList.filter(
+        (item) => item.id !== action.payload.id
+      );
+      const updateCartList = checkCartItem[0].isChecked
+        ? [
+            ...removeCheckCartItem,
+            { ...checkCartItem[0], isChecked: !checkCartItem[0].isChecked },
+          ]
+        : [
+            { ...checkCartItem[0], isChecked: !checkCartItem[0].isChecked },
+            ...removeCheckCartItem,
+          ];
+      const {
+        totalPrice,
+        checkItemAmount,
+        deliveryTips,
+        isAllChecked,
+      } = getUpdateState(updateCartList);
+      return {
+        cartList: updateCartList,
+        totalPrice,
+        deliveryTips,
+        checkItemAmount,
+        isAllChecked,
+      };
+    }
+    case "ALL_CHECK_CART_ITEM": {
+      const allCheckCartItem = state.cartList.map((item) => ({
+        ...item,
+        isChecked: !state.isAllChecked,
+      }));
+      const { totalPrice, checkItemAmount, deliveryTips } = getUpdateState(
+        allCheckCartItem
+      );
+      return {
+        cartList: allCheckCartItem,
+        totalPrice,
+        deliveryTips,
+        checkItemAmount,
+        isAllChecked: !state.isAllChecked,
+      };
+    }
+    default:
+      return state;
+  }
+};
+type CartDispatch = Dispatch<Action>;
+
+// Context 만들기
+const CartStateContext = createContext<Cart | null>(null);
+const CartDispatchContext = createContext<CartDispatch | null>(null);
+
+export const CartProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}): JSX.Element => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <CartStateContext.Provider value={state}>
+      <CartDispatchContext.Provider value={dispatch}>
+        {children}
+      </CartDispatchContext.Provider>
+    </CartStateContext.Provider>
+  );
+};
+
+// state 와 dispatch 를 쉽게 사용하기 위한 커스텀 Hooks
+export const useCartState = (): Cart => {
+  const state = useContext(CartStateContext);
+  if (!state) throw new Error("Cannot find SampleProvider"); // 유효하지 않을땐 에러를 발생
+  return state;
+};
+
+export const useCartDispatch = (): CartDispatch => {
+  const dispatch = useContext(CartDispatchContext);
+  if (!dispatch) throw new Error("Cannot find SampleProvider"); // 유효하지 않을땐 에러를 발생
+  return dispatch;
+};

--- a/frontend/src/context/index.ts
+++ b/frontend/src/context/index.ts
@@ -1,3 +1,4 @@
-import * as PopUpContext from "./popupContext";
+import * as PopUpContext from "./PopupContext";
+import * as CartContext from "./CartContext";
 
-export { PopUpContext };
+export { PopUpContext, CartContext };


### PR DESCRIPTION
> 프론트엔드 장바구니 페이지 상품 선택 및 수량 변경 기능 구현

구현 시간 : 3시간 15분
### related issue

- #100 

### content

- context api를 이용하여 장바구니 페이지 전역상태 추가
- 전역상태에는
  - 장바구니에 담긴 상품목록
  - 선택된 상품들의 총 구매 금액
  - 배달팁
  - 선택된 상품의 개수
  - 모든 상품이 선택되어 있는지 여부
  들이 있다.
- context api를 이용하여 장바구니 페이지에서 전역상태 데이터 가져오기
- 장바구니 페이지 상품별 체크박스 기능 구현
- 장바구니 페이지 상품별 수량 업데이트 기능 구현
- 장바구니 페이지 상단 체크박스 모두 선택 또는 선택 해제 기능 구현
- 장바구니 페이지 체크박스 기능에 총 구매금액과 선택된 상품 개수 변경 되도록 구현
