### PR TITLE
PR: 배포 스크립트 변경

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: frontend server CD
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.FRONTEND_HOST }}
+          username: ${{ secrets.FRONTEND_USERNAME }}
+          key: ${{ secrets.FRONTEND_KEY }}
+          script: |
+            sh deploy.sh
+
       - name: stop server via ssh and build
         uses: appleboy/ssh-action@master
         with:
@@ -21,12 +30,4 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            pm2 stop bmart-server
-            cd project/bmart-10
-            git pull origin release
-            cd /frontend
-            yarn install
-            yarn build
-            cd ../backend
-            yarn install
-            pm2 start bmart-server
+            sh deploy.sh

--- a/scripts/backend.deploy.sh
+++ b/scripts/backend.deploy.sh
@@ -1,0 +1,10 @@
+pm2 stop backend
+
+cd project/bmart-10/
+
+git pull origin release
+
+cd backend/
+yarn install
+
+pm2 start backend

--- a/scripts/frontend.deploy.sh
+++ b/scripts/frontend.deploy.sh
@@ -1,0 +1,7 @@
+cd project/bmart-10
+
+git pull origin release
+
+cd frontend/
+yarn install
+yarn build


### PR DESCRIPTION
> 배포용 스크립트를 변경함

### related issue

- #127

### content

프론트 서버와 백엔드 서버를 나눴기 때문에 ssh 접속을 두번하도록
수정함

또한 직접 명령어를 추가하지 않고 각각 deploy.sh 스크립트를 실행해
배포작업하도록 구성함

배포스크립트는 별도의 폴더에 추가함
