### PR TITLE
프론트엔드 장바구니 페이지 상품 추가, 삭제, 선택한 상품 비우기 기능 구현

### DIFF
--- a/frontend/src/components/cart/CartHeader.tsx
+++ b/frontend/src/components/cart/CartHeader.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import style from "styled-components";
 
 import { CheckBox } from "../common";
+import { CartContext } from "../../contexts";
 
 const HeaderWrapper = style.div`
   width: 100%;
@@ -20,28 +21,37 @@ const ToggleTitle = style.p`
   margin-left: 5px;
 `;
 
-type Props = {
-  isAllChecked: boolean;
-  onCheck: () => void;
-};
+const CartHeader = (): JSX.Element => {
+  const cartData = CartContext.useCartState();
+  const { isAllChecked } = cartData;
 
-const CartHeader = (props: Props): JSX.Element => {
-  const { isAllChecked, onCheck } = props;
+  const cartDispatch = CartContext.useCartDispatch();
+
+  const onAllCheck = (): void => {
+    cartDispatch({
+      type: "ALL_CHECK_CART_ITEM",
+    });
+  };
+
+  const onRemoveCheckedItem = (): void => {
+    cartDispatch({
+      type: "REMOVE_CHECKED_CART",
+    });
+  };
 
   return (
     <HeaderWrapper>
-      <ToggleCheck onClick={onCheck}>
+      <ToggleCheck onClick={onAllCheck}>
         <CheckBox isChecked={isAllChecked} />
         <ToggleTitle>{isAllChecked ? "선택 해제" : "모두 선택"}</ToggleTitle>
       </ToggleCheck>
-      <p>선택 비우기</p>
+      <p onClick={onRemoveCheckedItem}>선택 비우기</p>
     </HeaderWrapper>
   );
 };
 
 CartHeader.defaultProps = {
   isAllChecked: false,
-  onCheck: null,
 };
 
 export default CartHeader;

--- a/frontend/src/components/cart/CartList/CartItem.tsx
+++ b/frontend/src/components/cart/CartList/CartItem.tsx
@@ -5,6 +5,8 @@ import { COLOR } from "../../../constants/style";
 import { CheckBox } from "../../common";
 import { CartItemType } from "../../../types/Cart";
 
+import { CartContext } from "../../../contexts";
+
 const ItemWrapper = style.div`
   width: 100%;
   display: flex;
@@ -94,30 +96,61 @@ const CounterButton = style.button`
 
 type Props = {
   data: CartItemType;
-  onCheck: (id: number) => void;
-  onIncrease: (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    id: number
-  ) => void;
-  onDecrease: (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    id: number
-  ) => void;
 };
 
 const CartItem = (props: Props): JSX.Element => {
-  const { data, onCheck, onIncrease, onDecrease } = props;
+  const { data } = props;
   const { id, name, cost, discount, cnt, imageUrl, isChecked } = data;
   const salePrice = cost - Math.round(cost * (discount * 0.01));
+
+  const cartDispatch = CartContext.useCartDispatch();
+
+  const onCheckItem = (): void => {
+    cartDispatch({
+      type: "CHECK_CART_ITEM",
+      payload: {
+        id,
+      },
+    });
+  };
+
+  const onDecrease = (): void => {
+    cartDispatch({
+      type: "UPDATE_CART",
+      payload: {
+        id,
+        type: "minus",
+      },
+    });
+  };
+
+  const onIncrease = (): void => {
+    cartDispatch({
+      type: "UPDATE_CART",
+      payload: {
+        id,
+        type: "plus",
+      },
+    });
+  };
+
+  const onRemove = (): void => {
+    cartDispatch({
+      type: "REMOVE_CART",
+      payload: {
+        id,
+      },
+    });
+  };
 
   return (
     <ItemWrapper>
       <TitleWrapper>
-        <CheckBoxWrapper onClick={(): void => onCheck(id)}>
+        <CheckBoxWrapper onClick={onCheckItem}>
           <CheckBox isChecked={isChecked} />
           <p>{name}</p>
         </CheckBoxWrapper>
-        <DeleteBtn>삭제</DeleteBtn>
+        <DeleteBtn onClick={onRemove}>삭제</DeleteBtn>
       </TitleWrapper>
       <ContentWrapper>
         <ImgWrapper>
@@ -137,36 +170,18 @@ const CartItem = (props: Props): JSX.Element => {
           </div>
           <ChangeCounter>
             <CounterButton
-              name="minus"
               style={{ color: cnt === 1 ? COLOR.GREY_3 : COLOR.BLACK }}
-              onClick={(
-                e: React.MouseEvent<HTMLButtonElement, MouseEvent>
-              ): void => onDecrease(e, id)}
+              onClick={onDecrease}
             >
               ㅡ
             </CounterButton>
             <CounterItem>{cnt}</CounterItem>
-            <CounterButton
-              name="plus"
-              onClick={(
-                e: React.MouseEvent<HTMLButtonElement, MouseEvent>
-              ): void => onIncrease(e, id)}
-            >
-              +
-            </CounterButton>
+            <CounterButton onClick={onIncrease}>+</CounterButton>
           </ChangeCounter>
         </PriceWrapper>
       </ContentWrapper>
     </ItemWrapper>
   );
-};
-
-CartItem.defaultProps = {
-  goodId: 0,
-  title: "",
-  price: 0,
-  sale: 0,
-  src: "string",
 };
 
 export default CartItem;

--- a/frontend/src/components/cart/CartList/index.tsx
+++ b/frontend/src/components/cart/CartList/index.tsx
@@ -3,7 +3,6 @@ import style from "styled-components";
 
 import CartItem from "./CartItem";
 import { CartItemType } from "../../../types/Cart";
-import { CartContext } from "../../../contexts";
 
 const ListWrapper = style.div`
   width: 100%;
@@ -17,54 +16,12 @@ type Props = {
 const CartList = (props: Props): JSX.Element => {
   const { data } = props;
 
-  const cartDispatch = CartContext.useCartDispatch();
-
-  const onCheckItem = (id: number): void => {
-    cartDispatch({
-      type: "CHECK_CART_ITEM",
-      payload: {
-        id,
-      },
-    });
-  };
-
-  const onDecrease = (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    id: number
-  ): void => {
-    e.preventDefault();
-    cartDispatch({
-      type: "UPDATE_CART",
-      payload: {
-        id,
-        type: "minus",
-      },
-    });
-  };
-
-  const onIncrease = (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    id: number
-  ): void => {
-    e.preventDefault();
-    cartDispatch({
-      type: "UPDATE_CART",
-      payload: {
-        id,
-        type: "plus",
-      },
-    });
-  };
-
   return (
     <ListWrapper>
       {data.map((item, index) => (
         <CartItem
           key={index + item.name}
           data={item}
-          onCheck={onCheckItem}
-          onIncrease={onIncrease}
-          onDecrease={onDecrease}
         />
       ))}
     </ListWrapper>

--- a/frontend/src/components/cart/CartTotal.tsx
+++ b/frontend/src/components/cart/CartTotal.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import style from "styled-components";
 
 import { COLOR } from "../../constants/style";
+import { CartContext } from "../../contexts";
 
 type RowType = {
   justifyAttr?: string;
@@ -28,13 +29,10 @@ const Limit = style.div`
   color: ${COLOR.RED};
 `;
 
-type Props = {
-  totalPrice: number;
-  deliveryTips: number;
-};
+const CartTotal = (): JSX.Element => {
+  const cartData = CartContext.useCartState();
+  const { totalPrice, deliveryTips } = cartData;
 
-const CartTotal = (props: Props): JSX.Element => {
-  const { totalPrice, deliveryTips } = props;
   return (
     <TotalWrapper>
       <Row>
@@ -54,10 +52,6 @@ const CartTotal = (props: Props): JSX.Element => {
   );
 };
 
-CartTotal.defaultProps = {
-  totalPrice: 0,
-  deliveryTips: 0,
-};
 
 Row.defaultProps = {
   justifyAttr: "space-between",

--- a/frontend/src/components/cart/OrderBtn.tsx
+++ b/frontend/src/components/cart/OrderBtn.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import style from "styled-components";
+import { useHistory } from "react-router-dom";
 import { COLOR } from "../../constants/style";
+import { CartContext, PopUpContext } from "../../contexts";
+import { MESSAGE } from "../../constants/message";
 
 const BtnWrapper = style.div`
   width: 100%;
@@ -40,28 +43,42 @@ const Price = style.div`
   color: ${COLOR.WHITE};
 `;
 
-type Props = {
-  orderAction: () => void;
-  totalPrice: number;
-  count: number;
-};
+const OrderBtn = (): JSX.Element => {
+  const cartData = CartContext.useCartState();
+  const { totalPrice, checkItemAmount } = cartData;
 
-const OrderBtn = (props: Props): JSX.Element => {
-  const { orderAction, totalPrice, count } = props;
+  const history = useHistory();
+  const popupDispatch = PopUpContext.usePopUpDispatch();
+
+  const goLoginPage = (): void => {
+    popupDispatch({ type: "POPUP_CLOSE" });
+    history.push("/login");
+  };
+
+  const orderAction = (): void => {
+    const token = localStorage.getItem("token");
+    if (token) {
+      // 구매하기
+    } else {
+      // 로그인 페이지로 유도
+      popupDispatch({
+        type: "POPUP_OPEN",
+        payload: {
+          content: MESSAGE.LOGIN_INDUCE,
+          confirmAction: goLoginPage,
+        },
+      });
+    }
+  };
 
   return (
     <BtnWrapper>
       <Btn onClick={orderAction}>
-        <Count>{count}</Count>
+        <Count>{checkItemAmount}</Count>
         <Price>{totalPrice}원 배달 주문하기</Price>
       </Btn>
     </BtnWrapper>
   );
-};
-
-OrderBtn.defaultProps = {
-  totalPrice: 0,
-  count: 0,
 };
 
 export default OrderBtn;

--- a/frontend/src/contexts/CartContext.tsx
+++ b/frontend/src/contexts/CartContext.tsx
@@ -3,10 +3,10 @@ import { CartItemType } from "../types/Cart";
 
 type Cart = {
   cartList: Array<CartItemType>;
-  totalPrice?: number | undefined;
-  deliveryTips?: number | undefined;
-  checkItemAmount?: number | undefined;
-  isAllChecked?: boolean | undefined;
+  totalPrice: number;
+  deliveryTips: number;
+  checkItemAmount: number;
+  isAllChecked: boolean;
 };
 
 type CartState = {
@@ -180,22 +180,22 @@ const reducer = (state: Cart, action: Action): Cart => {
       };
     }
     case "UPDATE_CART": {
-      const updateCartItem = state.cartList.filter(
+      const updateCartItem: CartItemType | undefined = state.cartList.find(
         (item) => item.id === action.payload.id
       );
       const removeCheckCartItem = state.cartList.filter(
         (item) => item.id !== action.payload.id
       );
+      let updateCartList = [...removeCheckCartItem];
       let cnt = 0;
-      if (action.payload.type === "plus") {
-        cnt = updateCartItem[0].cnt + 1;
-      } else {
-        cnt = updateCartItem[0].cnt < 2 ? 1 : updateCartItem[0].cnt - 1;
+      if (updateCartItem) {
+        if (action.payload.type === "plus") {
+          cnt = updateCartItem.cnt + 1;
+        } else {
+          cnt = updateCartItem.cnt < 2 ? 1 : updateCartItem.cnt - 1;
+        }
+        updateCartList = [...removeCheckCartItem, { ...updateCartItem, cnt }];
       }
-      const updateCartList = [
-        ...removeCheckCartItem,
-        { ...updateCartItem[0], cnt },
-      ];
 
       const {
         totalPrice,
@@ -212,17 +212,39 @@ const reducer = (state: Cart, action: Action): Cart => {
       };
     }
     case "REMOVE_CART": {
-      const removeCheckCartItem = state.cartList.filter(
+      const removeCartItem = state.cartList.filter(
         (item) => item.id !== action.payload.id
       );
-      const { totalPrice, checkItemAmount, deliveryTips } = getUpdateState(
-        removeCheckCartItem
+      const {
+        totalPrice,
+        checkItemAmount,
+        deliveryTips,
+        isAllChecked,
+      } = getUpdateState(removeCartItem);
+      return {
+        cartList: removeCartItem,
+        totalPrice,
+        deliveryTips,
+        checkItemAmount,
+        isAllChecked,
+      };
+    }
+    case "REMOVE_CHECKED_CART": {
+      const removeCheckCartItem = state.cartList.filter(
+        (item) => !item.isChecked
       );
+      const {
+        totalPrice,
+        checkItemAmount,
+        deliveryTips,
+        isAllChecked,
+      } = getUpdateState(removeCheckCartItem);
       return {
         cartList: removeCheckCartItem,
         totalPrice,
         deliveryTips,
         checkItemAmount,
+        isAllChecked,
       };
     }
     case "CHECK_CART_ITEM": {

--- a/frontend/src/contexts/CartContext.tsx
+++ b/frontend/src/contexts/CartContext.tsx
@@ -24,6 +24,7 @@ type Action =
       type: "ADD_CART";
       payload: {
         data: CartItemType;
+        count: number;
       };
     }
   | {
@@ -140,8 +141,44 @@ const reducer = (state: Cart, action: Action): Cart => {
         isAllChecked,
       };
     }
-    case "ADD_CART":
-      return state;
+    case "ADD_CART": {
+      const updateItem = action.payload.data;
+      let updateCartList = [...state.cartList, updateItem];
+      console.log(action.payload);
+
+      // cart list에 이미 있는 상품인지 검사
+      const isItemCheck = state.cartList.find(
+        (cart): CartItemType | boolean => cart.id === updateItem.id
+      );
+      if (isItemCheck) {
+        const prevData = isItemCheck;
+        const prevCount = prevData.cnt;
+        const removeData = state.cartList.filter(
+          (cart): CartItemType | boolean => cart.id !== updateItem.id
+        );
+        updateCartList = [
+          ...removeData,
+          {
+            ...updateItem,
+            cnt: action.payload.count + prevCount,
+          },
+        ];
+      }
+
+      const {
+        totalPrice,
+        checkItemAmount,
+        deliveryTips,
+        isAllChecked,
+      } = getUpdateState(updateCartList);
+      return {
+        cartList: updateCartList,
+        totalPrice,
+        deliveryTips,
+        checkItemAmount,
+        isAllChecked,
+      };
+    }
     case "UPDATE_CART": {
       const updateCartItem = state.cartList.filter(
         (item) => item.id === action.payload.id

--- a/frontend/src/pages/Cart.tsx
+++ b/frontend/src/pages/Cart.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from "react";
 import style from "styled-components";
-import { useHistory } from "react-router-dom";
 import { Layout, ShadowBar } from "../components/common";
 import {
   OrderBtn,
@@ -9,8 +8,7 @@ import {
   CartTotal,
   NotCartItem,
 } from "../components/cart";
-import { PopUpContext, CartContext } from "../contexts";
-import { MESSAGE } from "../constants/message";
+import { CartContext } from "../contexts";
 
 const FakeComp = style.div`
   height: 80px;
@@ -27,61 +25,20 @@ const Cart = (): JSX.Element => {
   }, []);
 
   const cartData = CartContext.useCartState();
-  const {
-    cartList,
-    totalPrice,
-    deliveryTips,
-    checkItemAmount,
-    isAllChecked,
-  } = cartData;
-
+  const { cartList } = cartData;
   const isCart = cartList.length > 0 ? true : false; // 장바구니에 담긴 상품이 있는지 여부
-
-  const history = useHistory();
-  const popupDispatch = PopUpContext.usePopUpDispatch();
-
-  const onAllCheck = (): void => {
-    cartDispatch({
-      type: "ALL_CHECK_CART_ITEM",
-    });
-  };
-
-  const goLoginPage = (): void => {
-    popupDispatch({ type: "POPUP_CLOSE" });
-    history.push("/login");
-  };
-
-  const orderAction = (): void => {
-    const token = localStorage.getItem("token");
-    if (token) {
-      // 구매하기
-    } else {
-      // 로그인 페이지로 유도
-      popupDispatch({
-        type: "POPUP_OPEN",
-        payload: {
-          content: MESSAGE.LOGIN_INDUCE,
-          confirmAction: goLoginPage,
-        },
-      });
-    }
-  };
 
   return (
     <Layout>
       {isCart ? (
         <>
-          <CartHeader isAllChecked={isAllChecked} onCheck={onAllCheck} />
+          <CartHeader />
           <ShadowBar />
           <CartList data={cartList} />
           <ShadowBar />
-          <CartTotal totalPrice={totalPrice} deliveryTips={deliveryTips} />
+          <CartTotal />
           <FakeComp />
-          <OrderBtn
-            orderAction={orderAction}
-            totalPrice={totalPrice}
-            count={checkItemAmount}
-          />
+          <OrderBtn />
         </>
       ) : (
         <NotCartItem />


### PR DESCRIPTION
> 프론트엔드 장바구니 페이지 상품 추가, 삭제, 선택한 상품 비우기 기능 구현

### related issue

- #100 

### content

- 상품 상세페이지에서 장바구니에 상품 담기 기능 구현
- 장바구니 페이지에서 상품 단일 삭제 기능 구현
- 장바구니 페이지에서 선택한 상품 비우기 구현
- 장바구니 페이지에서 prop으로 넘기는 전역 상태를 각 컴포넌트에서 사용하도록 수정
- 장바구니 페이지에서 상품을 선택/해제 하거나 수량이 바뀔 때 상품들의 순서가 변경되지 않도록 수정
- filter를 사용해서 찾았던 상품을 find 함수로 변경


추가로 components/goods/index.tsx에서 addCart 함수에 dispatch가 나란히 호출 되는데
추후에 상품이 담기고 나서 팝업이 호출되도록  리팩토링 예정