### PR TITLE
백엔드 장바구니 api 구현

### DIFF
--- a/backend/src/apis/cartAPI.ts
+++ b/backend/src/apis/cartAPI.ts
@@ -94,9 +94,8 @@ router.post("/", async (request: Request, response: Response) => {
   }
 
   const data = { ...request.body, email: userEmail };
-  console.log(data);
-  await cartDao.createCartItem(data);
-  apiResponse.success = true;
+  const result = await cartDao.createCartItem(data);
+  apiResponse.success = result;
 
   response.status(200).send(apiResponse);
 });
@@ -107,7 +106,7 @@ router.post("/", async (request: Request, response: Response) => {
  * @apiName Get Cart list
  * @apiGroup Cart
  *
- * @apiParam {String} id       상품 아이디.
+ * @apiParam {String} list       삭제할상품 아이디 리스트.
  *
  * @apiSuccess {Boolean} success API 성공 여부
  *
@@ -126,31 +125,34 @@ router.post("/", async (request: Request, response: Response) => {
  *     }
  */
 
-router.delete("/:id", async (request: Request, response: Response) => {
+router.delete("/", async (request: Request, response: Response) => {
   // 사용자 정보 받기
   const userEmail = "tmfrl002@naver.com";
-  const { id } = request.params;
+  const { list } = request.body;
   const apiResponse: APIResponse = {
     success: false,
   };
 
-  if (!userEmail || !request.params) {
+  if (!userEmail || !request.body) {
     response.status(404).send(apiResponse);
 
     return;
   }
 
-  await cartDao.removeCartItem(id, userEmail);
-  apiResponse.success = true;
+  const result = await cartDao.removeCartItem(list, userEmail);
+  apiResponse.success = result;
 
   response.status(200).send(apiResponse);
 });
 
 /**
- * @api {put} /api/cart 장바구니 목록 개수 업데이트
+ * @api {put} /api/cart 장바구니 상풍 목록 개수 업데이트
  * @apiHeader {String} Authorization Users unique token.
  * @apiName Update Cart
  * @apiGroup Cart
+ *
+ * @apiParam {String} id       상품 아이디.
+ * @apiParam {Number} amount        상품 개수.
  *
  * @apiSuccess {Boolean} success API 성공 여부
  *
@@ -184,10 +186,76 @@ router.patch("/", async (request: Request, response: Response) => {
 
   const data = { ...request.body, email: userEmail };
 
-  await cartDao.updateCartItem(data);
+  await cartDao.updateCartItemAmount(data);
   apiResponse.success = true;
 
   response.status(200).send(apiResponse);
 });
 
+/**
+ * @api {put} /api/cart/checked 장바구니 상품 체크 상태 변경
+ * @apiHeader {String} Authorization Users unique token.
+ * @apiName Update Cart
+ * @apiGroup Cart
+ *
+ * @apiParam {String} id       상품 아이디.
+ * @apiParam {String} checked        상품 체크 상태.
+ *
+ * @apiSuccess {Boolean} success API 성공 여부
+ *
+ * @apiSuccessExample Success-Response:
+ *     HTTP/1.1 201 OK
+ *     {
+ *       "success": true
+ *     }
+ *
+ * @apiError NotFound
+ *
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "success": false,
+ *     }
+ */
+
+router.patch("/checked", async (request: Request, response: Response) => {
+  // 사용자 정보 받기
+  const userEmail = "tmfrl002@naver.com";
+  const apiResponse: APIResponse = {
+    success: false,
+  };
+
+  if (!userEmail || !request.body) {
+    response.status(404).send(apiResponse);
+
+    return;
+  }
+
+  const data = { ...request.body, email: userEmail };
+
+  const result = await cartDao.updateCartItemChecked(data);
+  apiResponse.success = result;
+
+  response.status(200).send(apiResponse);
+});
+
+router.patch("/checked/all", async (request: Request, response: Response) => {
+  // 사용자 정보 받기
+  const userEmail = "tmfrl002@naver.com";
+  const { checked } = request.body;
+  const apiResponse: APIResponse = {
+    success: false,
+  };
+
+  if (!userEmail || !request.body) {
+    response.status(404).send(apiResponse);
+
+    return;
+  }
+
+  const result = await cartDao.updateAllCartItemChecked(userEmail, checked);
+  apiResponse.success = result;
+
+  response.status(200).send(apiResponse);
+});
 export default router;

--- a/backend/src/apis/cartAPI.ts
+++ b/backend/src/apis/cartAPI.ts
@@ -1,0 +1,193 @@
+import { Router, Request, Response } from "express";
+import { APIResponse } from "../types/APIResponse";
+
+import cartDao from "../daos/cart.dao";
+
+const router = Router();
+
+/**
+ * @api {get} /api/cart 장바구니 목록 조회
+ * @apiHeader {String} Authorization Users unique token.
+ * @apiName Cart list
+ * @apiGroup Cart
+ *
+ * @apiSuccess {Boolean} success API 성공 여부
+ * @apiSuccess {Object[]} data 사용자 장바구니 목록
+ *
+ * @apiSuccessExample Success-Response:
+ *     HTTP/1.1 200 OK
+ *     {
+ *       "success": true,
+ *       "data" : [
+ *          "cartList" : []
+ *       ]
+ *     }
+ *
+ * @apiError NotFound
+ *
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "success": false,
+ *     }
+ */
+
+router.get("/", async (request: Request, response: Response) => {
+  // 사용자 정보 받기
+  const userEmail = "tmfrl002@naver.com";
+  const apiResponse: APIResponse = {
+    success: false,
+  };
+
+  if (!userEmail) {
+    response.status(404).send(apiResponse);
+
+    return;
+  }
+
+  const result = await cartDao.getCartList(userEmail);
+  apiResponse.success = true;
+  apiResponse.data = {
+    cartList: result,
+  };
+
+  response.status(200).send(apiResponse);
+});
+
+/**
+ * @api {post} /api/cart 장바구니 목록 추가
+ * @apiHeader {String} Authorization Users unique token.
+ * @apiName Cart list
+ * @apiGroup Cart
+ *
+ * @apiParam {String} good_id       상품 아이디.
+ * @apiParam {String} amount        상품 개수.
+ *
+ * @apiSuccess {Boolean} success API 성공 여부
+ *
+ * @apiSuccessExample Success-Response:
+ *     HTTP/1.1 201 OK
+ *     {
+ *       "success": true
+ *     }
+ *
+ * @apiError NotFound
+ *
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "success": false,
+ *     }
+ */
+
+router.post("/", async (request: Request, response: Response) => {
+  // 사용자 정보 받기
+  const userEmail = "tmfrl002@naver.com";
+  const apiResponse: APIResponse = {
+    success: false,
+  };
+
+  if (!userEmail || !request.body) {
+    response.status(404).send(apiResponse);
+
+    return;
+  }
+
+  const data = { ...request.body, email: userEmail };
+  console.log(data);
+  await cartDao.createCartItem(data);
+  apiResponse.success = true;
+
+  response.status(200).send(apiResponse);
+});
+
+/**
+ * @api {delete} /api/cart 장바구니 목록 삭제
+ * @apiHeader {String} Authorization Users unique token.
+ * @apiName Get Cart list
+ * @apiGroup Cart
+ *
+ * @apiParam {String} id       상품 아이디.
+ *
+ * @apiSuccess {Boolean} success API 성공 여부
+ *
+ * @apiSuccessExample Success-Response:
+ *     HTTP/1.1 201 OK
+ *     {
+ *       "success": true
+ *     }
+ *
+ * @apiError NotFound
+ *
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "success": false,
+ *     }
+ */
+
+router.delete("/:id", async (request: Request, response: Response) => {
+  // 사용자 정보 받기
+  const userEmail = "tmfrl002@naver.com";
+  const { id } = request.params;
+  const apiResponse: APIResponse = {
+    success: false,
+  };
+
+  if (!userEmail || !request.params) {
+    response.status(404).send(apiResponse);
+
+    return;
+  }
+
+  await cartDao.removeCartItem(id, userEmail);
+  apiResponse.success = true;
+
+  response.status(200).send(apiResponse);
+});
+
+/**
+ * @api {put} /api/cart 장바구니 목록 개수 업데이트
+ * @apiHeader {String} Authorization Users unique token.
+ * @apiName Update Cart
+ * @apiGroup Cart
+ *
+ * @apiSuccess {Boolean} success API 성공 여부
+ *
+ * @apiSuccessExample Success-Response:
+ *     HTTP/1.1 201 OK
+ *     {
+ *       "success": true
+ *     }
+ *
+ * @apiError NotFound
+ *
+ * @apiErrorExample Error-Response:
+ *     HTTP/1.1 404 Not Found
+ *     {
+ *       "success": false,
+ *     }
+ */
+
+router.patch("/", async (request: Request, response: Response) => {
+  // 사용자 정보 받기
+  const userEmail = "tmfrl002@naver.com";
+  const apiResponse: APIResponse = {
+    success: false,
+  };
+
+  if (!userEmail || !request.body) {
+    response.status(404).send(apiResponse);
+
+    return;
+  }
+
+  const data = { ...request.body, email: userEmail };
+
+  await cartDao.updateCartItem(data);
+  apiResponse.success = true;
+
+  response.status(200).send(apiResponse);
+});
+
+export default router;

--- a/backend/src/apis/index.ts
+++ b/backend/src/apis/index.ts
@@ -3,11 +3,13 @@ import { Router } from "express";
 import goodsAPI from "./goodsAPI";
 import categoryAPI from "./categoryAPI";
 import userAPI from "./userAPI";
+import cartAPI from "./cartAPI";
 
 const router = Router();
 
 router.use("/goods", goodsAPI);
 router.use("/category", categoryAPI);
 router.use("/user", userAPI);
+router.use("/cart", cartAPI);
 
 export default router;

--- a/backend/src/daos/cart.dao.ts
+++ b/backend/src/daos/cart.dao.ts
@@ -1,0 +1,139 @@
+import mysql from "mysql2/promise";
+import DAO from "./data-access-object";
+import poolOption from "./pool-option";
+import { CartListItem, UserCartList, CartItem } from '../types/dto/cart.dto';
+
+const GET_CART_LIST = `SELECT * FROM cart WHERE fk_user_email = ?`;
+const GET_GOODS_ITEM = `SELECT * FROM goods WHERE good_id IN `;
+const CREATE_CART_ITEM = `INSERT INTO cart (fk_user_email, fk_good_id, amount) VALUES (?, ?, ?)`;
+const UPDATE_CART_ITEM = `UPDATE cart SET amount = ? WHERE fk_user_email = ? AND fk_good_id = ?`;
+const DELETE_CART_ITEM = `DELETE FROM cart WHERE fk_user_email = ? AND fk_good_id = ?`;
+
+class CartDAO extends DAO {
+  constructor(option: mysql.PoolOptions) {
+    super(option);
+  }
+
+  async getCartList(email: string): Promise<CartListItem[]> {
+    const connection = await this.getConnection();
+    let result: CartListItem[] = [];
+
+    try {
+      await connection.beginTransaction();
+
+      let userCartList: UserCartList[] = [];
+      let cartItemIdList: string[] = [];
+      let goodItemLength = "";
+      const rows = await this.executeQuery(connection, GET_CART_LIST, [email]);
+
+      if (rows instanceof Array) {
+        rows.forEach((row: any, index: number) => {
+          const curData: UserCartList = {
+            id: row.fk_good_id,
+            amount: row.amount,
+          };
+          userCartList = userCartList.concat(curData);
+          goodItemLength += index === rows.length - 1 ? "?" : "?,";
+          cartItemIdList = cartItemIdList.concat(row.fk_good_id);
+        });
+      }
+
+      const cartItemRows = await this.executeQuery(
+        connection,
+        GET_GOODS_ITEM + `(${goodItemLength})`,
+        cartItemIdList
+      );
+
+      if (cartItemRows instanceof Array) {
+        cartItemRows.forEach((row: any) => {
+          const findCartItem = userCartList.find(
+            (item) => item.id === row.good_id
+          );
+          const curData: CartListItem = {
+            id: row.good_id,
+            title: row.title,
+            cost: row.cost,
+            discount: row.discount,
+            amount: findCartItem?.amount || 1,
+            image_url: row.image_url,
+          };
+          result = result.concat(curData);
+        });
+      }
+
+      await connection.commit();
+    } catch (error) {
+      console.log(error);
+      connection.rollback();
+    } finally {
+      connection.release();
+    }
+    return result;
+  }
+
+  async createCartItem(data: CartItem) {
+    const connection = await this.getConnection();
+    let result = false;
+    try {
+      await connection.beginTransaction();
+      const { id, email, amount } = data;
+      await this.executeQuery(connection, CREATE_CART_ITEM, [
+        email,
+        id,
+        `${amount}`,
+      ]);
+
+      result = true;
+      await connection.commit();
+    } catch (error) {
+      console.log(error);
+      connection.rollback();
+    } finally {
+      connection.release();
+    }
+    return result;
+  }
+
+  async updateCartItem(data: CartItem) {
+    const connection = await this.getConnection();
+    let result = false;
+    try {
+      await connection.beginTransaction();
+      const { id, email, amount } = data;
+      await this.executeQuery(connection, UPDATE_CART_ITEM, [
+        `${amount}`,
+        email,
+        id,
+      ]);
+
+      result = true;
+      await connection.commit();
+    } catch (error) {
+      console.log(error);
+      connection.rollback();
+    } finally {
+      connection.release();
+    }
+    return result;
+  }
+
+  async removeCartItem(id: string, email: string) {
+    const connection = await this.getConnection();
+    let result = false;
+    try {
+      await connection.beginTransaction();
+      await this.executeQuery(connection, DELETE_CART_ITEM, [email, id]);
+
+      result = true;
+      await connection.commit();
+    } catch (error) {
+      console.log(error);
+      connection.rollback();
+    } finally {
+      connection.release();
+    }
+    return result;
+  }
+}
+
+export default new CartDAO(poolOption);

--- a/backend/src/daos/cart.dao.ts
+++ b/backend/src/daos/cart.dao.ts
@@ -1,13 +1,29 @@
 import mysql from "mysql2/promise";
 import DAO from "./data-access-object";
 import poolOption from "./pool-option";
-import { CartListItem, UserCartList, CartItem } from '../types/dto/cart.dto';
+import { CartListItem, UserCartList, CartItem } from "../types/dto/cart.dto";
 
-const GET_CART_LIST = `SELECT * FROM cart WHERE fk_user_email = ?`;
-const GET_GOODS_ITEM = `SELECT * FROM goods WHERE good_id IN `;
-const CREATE_CART_ITEM = `INSERT INTO cart (fk_user_email, fk_good_id, amount) VALUES (?, ?, ?)`;
-const UPDATE_CART_ITEM = `UPDATE cart SET amount = ? WHERE fk_user_email = ? AND fk_good_id = ?`;
-const DELETE_CART_ITEM = `DELETE FROM cart WHERE fk_user_email = ? AND fk_good_id = ?`;
+const GET_CART_ITEM_LIST = `SELECT
+  good_id,
+  cart.amount,
+  checked,
+  title,
+  category_name AS categoryName,
+  discount,
+  cost,
+  image_url AS imageUrl
+from cart
+JOIN goods
+ON goods.good_id = cart.fk_good_id
+WHERE fk_user_email = ?`;
+
+const GET_CART_ITEM_BY_ID = `SELECT * FROM cart WHERE fk_good_id = ?`;
+const CREATE_CART_ITEM = `INSERT INTO cart (fk_user_email, fk_good_id, amount, checked) VALUES (?, ?, ?, ?)`;
+const UPDATE_CART_ITEM_AMOUNT_INCREASE = `UPDATE cart SET amount = amount + ? WHERE fk_user_email = ? AND fk_good_id = ?`;
+const UPDATE_CART_ITEM_AMOUNT = `UPDATE cart SET amount = ? WHERE fk_user_email = ? AND fk_good_id = ?`;
+const UPDATE_CART_ITEM_CHECKED = `UPDATE cart SET checked = ? WHERE fk_user_email = ? AND fk_good_id = ?`;
+const UPDATE_ALL_CART_ITEM_CHECKED = `UPDATE cart SET checked = ? WHERE fk_user_email = ?`;
+const DELETE_CART_ITEM = `DELETE FROM cart WHERE fk_user_email = ? AND fk_good_id IN `;
 
 class CartDAO extends DAO {
   constructor(option: mysql.PoolOptions) {
@@ -20,46 +36,49 @@ class CartDAO extends DAO {
 
     try {
       await connection.beginTransaction();
-
-      let userCartList: UserCartList[] = [];
-      let cartItemIdList: string[] = [];
-      let goodItemLength = "";
-      const rows = await this.executeQuery(connection, GET_CART_LIST, [email]);
-
+      const rows = await this.executeQuery(connection, GET_CART_ITEM_LIST, [
+        email,
+      ]);
       if (rows instanceof Array) {
         rows.forEach((row: any, index: number) => {
-          const curData: UserCartList = {
-            id: row.fk_good_id,
-            amount: row.amount,
-          };
-          userCartList = userCartList.concat(curData);
-          goodItemLength += index === rows.length - 1 ? "?" : "?,";
-          cartItemIdList = cartItemIdList.concat(row.fk_good_id);
-        });
-      }
-
-      const cartItemRows = await this.executeQuery(
-        connection,
-        GET_GOODS_ITEM + `(${goodItemLength})`,
-        cartItemIdList
-      );
-
-      if (cartItemRows instanceof Array) {
-        cartItemRows.forEach((row: any) => {
-          const findCartItem = userCartList.find(
-            (item) => item.id === row.good_id
-          );
           const curData: CartListItem = {
             id: row.good_id,
             title: row.title,
             cost: row.cost,
             discount: row.discount,
-            amount: findCartItem?.amount || 1,
+            amount: row.amount,
             image_url: row.image_url,
+            checked: row.checked,
           };
           result = result.concat(curData);
+          // goodItemLength += index === rows.length - 1 ? "?" : "?,";
+          // cartItemIdList = cartItemIdList.concat(row.fk_good_id);
         });
       }
+
+      // const cartItemRows = await this.executeQuery(
+      //   connection,
+      //   GET_GOODS_ITEM + `(${goodItemLength})`,
+      //   cartItemIdList
+      // );
+
+      // if (cartItemRows instanceof Array) {
+      //   cartItemRows.forEach((row: any) => {
+      //     const findCartItem = userCartList.find(
+      //       (item) => item.id === row.good_id
+      //     );
+      //     const curData: CartListItem = {
+      //       id: row.good_id,
+      //       title: row.title,
+      //       cost: row.cost,
+      //       discount: row.discount,
+      //       amount: findCartItem?.amount || 1,
+      //       image_url: row.image_url,
+      //       checked: findCartItem?.checked || "true",
+      //     };
+      //     result = result.concat(curData);
+      //   });
+      // }
 
       await connection.commit();
     } catch (error) {
@@ -77,12 +96,28 @@ class CartDAO extends DAO {
     try {
       await connection.beginTransaction();
       const { id, email, amount } = data;
-      await this.executeQuery(connection, CREATE_CART_ITEM, [
-        email,
-        id,
-        `${amount}`,
-      ]);
+      const cartItemExist = await this.executeQuery(
+        connection,
+        GET_CART_ITEM_BY_ID,
+        [id]
+      );
 
+      if (Array.isArray(cartItemExist)) {
+        if (cartItemExist[0]) {
+          await this.executeQuery(
+            connection,
+            UPDATE_CART_ITEM_AMOUNT_INCREASE,
+            [`${amount}`, email, id]
+          );
+        } else {
+          await this.executeQuery(connection, CREATE_CART_ITEM, [
+            email,
+            id,
+            `${amount}`,
+            "true",
+          ]);
+        }
+      }
       result = true;
       await connection.commit();
     } catch (error) {
@@ -94,13 +129,13 @@ class CartDAO extends DAO {
     return result;
   }
 
-  async updateCartItem(data: CartItem) {
+  async updateCartItemAmount(data: CartItem) {
     const connection = await this.getConnection();
     let result = false;
     try {
       await connection.beginTransaction();
       const { id, email, amount } = data;
-      await this.executeQuery(connection, UPDATE_CART_ITEM, [
+      await this.executeQuery(connection, UPDATE_CART_ITEM_AMOUNT, [
         `${amount}`,
         email,
         id,
@@ -117,12 +152,65 @@ class CartDAO extends DAO {
     return result;
   }
 
-  async removeCartItem(id: string, email: string) {
+  async updateCartItemChecked(data: CartItem) {
     const connection = await this.getConnection();
     let result = false;
     try {
       await connection.beginTransaction();
-      await this.executeQuery(connection, DELETE_CART_ITEM, [email, id]);
+      const { id, email, checked } = data;
+      await this.executeQuery(connection, UPDATE_CART_ITEM_CHECKED, [
+        checked,
+        email,
+        id,
+      ]);
+
+      result = true;
+      await connection.commit();
+    } catch (error) {
+      console.log(error);
+      connection.rollback();
+    } finally {
+      connection.release();
+    }
+    return result;
+  }
+
+  async updateAllCartItemChecked(email: string, checked: string) {
+    const connection = await this.getConnection();
+    let result = false;
+    try {
+      await connection.beginTransaction();
+      await this.executeQuery(connection, UPDATE_ALL_CART_ITEM_CHECKED, [
+        checked,
+        email,
+      ]);
+
+      result = true;
+      await connection.commit();
+    } catch (error) {
+      console.log(error);
+      connection.rollback();
+    } finally {
+      connection.release();
+    }
+    return result;
+  }
+
+  async removeCartItem(list: string, email: string) {
+    const connection = await this.getConnection();
+    let result = false;
+    try {
+      await connection.beginTransaction();
+      let goodItemLength = "";
+      const removeList = list.split(",");
+      removeList.forEach((item: string, index) => {
+        goodItemLength += index === removeList.length - 1 ? "?" : "?,";
+      });
+      await this.executeQuery(
+        connection,
+        DELETE_CART_ITEM + `(${goodItemLength})`,
+        [email, ...removeList]
+      );
 
       result = true;
       await connection.commit();

--- a/backend/src/types/dto/cart.dto.ts
+++ b/backend/src/types/dto/cart.dto.ts
@@ -1,0 +1,19 @@
+export type CartItem = {
+  email: string;
+  id: string;
+  amount: number;
+};
+
+export type UserCartList = {
+  id: string;
+  amount: number;
+};
+
+export type CartListItem = {
+  id: number;
+  title: string;
+  cost: number;
+  discount: number;
+  amount: number;
+  image_url: string;
+};

--- a/backend/src/types/dto/cart.dto.ts
+++ b/backend/src/types/dto/cart.dto.ts
@@ -2,11 +2,13 @@ export type CartItem = {
   email: string;
   id: string;
   amount: number;
+  checked: string;
 };
 
 export type UserCartList = {
   id: string;
   amount: number;
+  checked: string;
 };
 
 export type CartListItem = {
@@ -16,4 +18,5 @@ export type CartListItem = {
   discount: number;
   amount: number;
   image_url: string;
+  checked: string;
 };


### PR DESCRIPTION
>백엔드 장바구니 api 구현

### related issue

- #84 

### content

- 장바구니 상품 목록 조회 api 추가
- 장바구니 상품 추가 api 추가
- 장바구니 상품 수량 업데이트 api 추가
- 장바구니 상품 삭제 api 추가
- 각각에 필요한 router 추가와 dao, dto 추가
- 장바구니 상품 추가할 때 이미 담겨있는 상품이면
  개수 업데이트 하도록 기존 ap에i 추가 구현
- 장바구니 상품 단일, 다중 삭제 가능하도록 기존 api에 추가 구현
- 장바구니 상품 체크 상태 변경해주는 api 구현
- 장바구니 모든 상품 체크 상태 변경해주는 api 구현


