### PR TITLE
feat: 프론트엔드 로그인 페이지 api 연동

### DIFF
--- a/backend/src/apis/userAPI.ts
+++ b/backend/src/apis/userAPI.ts
@@ -50,7 +50,8 @@ router.post("/register", async (request: Request, response: Response) => {
  * @apiName UserLogin
  * @apiGroup User
  *
- * @apiParam {String} email password
+ * @apiParam {String} email
+ * @apiParam {String} password
  *
  * @apiSuccess {Boolean} success API 성공 여부
  * @apiSuccess {Object} data name token 포함된 객체
@@ -122,7 +123,6 @@ router.post(
  */
 router.get("/email/:email", async (request: Request, response: Response) => {
   const email = request.params.email.trim();
-
   const apiResponse: APIResponse = {
     success: false,
   };

--- a/frontend/src/constants/message.ts
+++ b/frontend/src/constants/message.ts
@@ -59,6 +59,10 @@ export const MESSAGE = {
   LOGIN_INDUCE: "로그인 후 주문이 가능합니다. \n 로그인 후 주문하시겠습니까?",
   ADD_CART:
     "장바구니에 상품을 담았습니다. \n 장바구니 페이지로 이동하시겠습니까?",
+  USER_LOGIN_ERROR: "로그인에 실패하였습니다. \n 다시 시도해주세요.",
+  USER_EMAIL_EMPTY: "이메일을 입력해주세요.",
+  USER_PASSWORD_EMPTY: "비밀번호를 입력해주세요.",
+  USER_EMAIL_EXIST: "입력하신 이메일은 존재하는 이메일입니다. \n 다른 이메일을 입력해 주세요.",
 };
 
 type CategoryTitleName = { name: string; title: string };

--- a/frontend/src/fetch/user/emailCheck.ts
+++ b/frontend/src/fetch/user/emailCheck.ts
@@ -1,0 +1,22 @@
+import { API_HOST } from "../../constants/API";
+
+export type APIResponse =
+  | {
+      success: false;
+    }
+  | {
+      success: true;
+      isUserEmail: boolean;
+    };
+
+type User = {
+  email: string;
+  password: string;
+};
+
+export default async function emailCheck(email: string): Promise<APIResponse> {
+  return await fetch(`${API_HOST}/api/user/email/${email}`, {
+    mode: "cors",
+    method: "GET",
+  }).then((res) => res.json());
+}

--- a/frontend/src/fetch/user/getToken.ts
+++ b/frontend/src/fetch/user/getToken.ts
@@ -1,0 +1,29 @@
+import { API_HOST } from "../../constants/API";
+
+export type APIResponse =
+  | {
+      success: false;
+    }
+  | {
+      success: true;
+      data: {
+        token: string;
+      };
+    };
+
+type User = {
+  email: string;
+  password: string;
+};
+
+export default async function getToken(data: User): Promise<APIResponse> {
+  return await fetch(`${API_HOST}/api/user/login`, {
+    mode: "cors",
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      // 'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: JSON.stringify(data),
+  }).then((res) => res.json());
+}

--- a/frontend/src/fetch/user/index.ts
+++ b/frontend/src/fetch/user/index.ts
@@ -1,0 +1,5 @@
+import getToken from "./getToken";
+import emailCheck from "./emailCheck";
+import userRegister from "./userRegister";
+
+export { getToken, emailCheck, userRegister };

--- a/frontend/src/fetch/user/userRegister.ts
+++ b/frontend/src/fetch/user/userRegister.ts
@@ -1,0 +1,22 @@
+import { API_HOST } from "../../constants/API";
+
+export type APIResponse =
+  | {
+      success: false;
+    }
+  | {
+      success: true;
+    };
+
+type User = {
+  email: string;
+  password: string;
+};
+
+export default async function userRegister(data: User): Promise<APIResponse> {
+  return await fetch(`${API_HOST}/api/user/register`, {
+    mode: "cors",
+    method: "POST",
+    body: JSON.stringify(data),
+  }).then((res) => res.json());
+}


### PR DESCRIPTION

### related issue

- #143 

### content
- 로그인 화면에서 필요한 메세지 상수 추가
- fetch/user 폴더 생성
- getToken, emailCheck, userRegister api 구현
- 로그인 페이지에서 이메일, 비밀번호 없으면 입력 요구 팝업 띄워주기
- 로그인 페이지에서 로그인 api(getToken) api 연동 => 토큰 localstorage에 저장

