### PR TITLE
장바구니 페이지 개수 기능 수정

### DIFF
--- a/frontend/src/components/cart/CartList/CartItem.tsx
+++ b/frontend/src/components/cart/CartList/CartItem.tsx
@@ -130,11 +130,12 @@ const CartItem = (props: Props): JSX.Element => {
   };
 
   const onIncrease = (): void => {
+    const count = amount < 10 ? amount + 1 : 10;
     cartDispatch({
       type: "UPDATE_CART",
       payload: {
         id,
-        amount: amount + 1,
+        amount: count,
       },
     });
   };
@@ -181,7 +182,12 @@ const CartItem = (props: Props): JSX.Element => {
               ㅡ
             </CounterButton>
             <CounterItem>{amount}</CounterItem>
-            <CounterButton onClick={onIncrease}>+</CounterButton>
+            <CounterButton
+              style={{ color: amount === 10 ? COLOR.GREY_3 : COLOR.BLACK }}
+              onClick={onIncrease}
+            >
+              +
+            </CounterButton>
           </ChangeCounter>
         </PriceWrapper>
       </ContentWrapper>

--- a/frontend/src/components/cart/OrderBtn.tsx
+++ b/frontend/src/components/cart/OrderBtn.tsx
@@ -95,8 +95,8 @@ const OrderBtn = (): JSX.Element => {
       <Btn onClick={orderAction}>
         {totalPrice >= 5000 ? (
           <>
-            <Count>{checkItemAmount}</Count>
-            <Price>{totalPrice}원 배달 주문하기</Price>
+            <Count>{checkItemAmount >= 100 ? 99 : checkItemAmount}</Count>
+            <Price>{totalPrice.toLocaleString()}원 배달 주문하기</Price>
           </>
         ) : (
           <Price>최소 금액을 맞춰주세요.</Price>

--- a/frontend/src/components/common/Layout/Footer.tsx
+++ b/frontend/src/components/common/Layout/Footer.tsx
@@ -8,6 +8,7 @@ import { COLOR, SVG_ICON } from "../../../constants/style";
 import { FOOTER } from "../../../constants/layout";
 
 import * as ROUTES from "../../../constants/routes";
+import { CartContext } from "../../../contexts";
 
 const Wrap = styled.div`
   position: fixed;
@@ -45,6 +46,20 @@ const Item = styled.div`
   justify-content: center;
 `;
 
+const CartAmount = styled.div`
+  width: 25px;
+  height: 25px;
+  background: ${COLOR.GREEN_1};
+  color: ${COLOR.WHITE};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 13px;
+  position: absolute;
+  top: 5px;
+  margin-left: 40px;
+`;
+
 const navList = [
   {
     path: ROUTES.HOME.path,
@@ -75,6 +90,8 @@ type Props = {
 };
 
 const NavItem = (props: Props): JSX.Element => {
+  const cartData = CartContext.useCartState();
+  const { checkItemAmount } = cartData;
   const { path, name, svg } = props;
   return (
     <NavLink exact to={path} activeClassName="nav_selected" className="nav">
@@ -83,6 +100,11 @@ const NavItem = (props: Props): JSX.Element => {
           window.onscroll = null;
         }}
       >
+        {path === "/cart" && checkItemAmount !== 0 && (
+          <CartAmount>
+            {checkItemAmount >= 100 ? 99 : checkItemAmount}
+          </CartAmount>
+        )}
         <Svg size={36} fill={COLOR.GREY_2} path={svg} />
         <p>{name}</p>
       </Item>


### PR DESCRIPTION

> 장바구니 페이지 개수 기능 수정

### related issue

- #1
- #2

### content

- 장바구니 페이지 상품의 개수는 한 상품당 10개만 가능하도록 구현
- 탭 네비게이션의 장바구니 버튼에 개수 추가

